### PR TITLE
Teach players of crafting recipe

### DIFF
--- a/src/main/java/au/com/grieve/portalnetwork/PortalManager.java
+++ b/src/main/java/au/com/grieve/portalnetwork/PortalManager.java
@@ -66,6 +66,10 @@ public class PortalManager {
     private final Hashtable<BlockVector, BasePortal> indexBases = new Hashtable<>();
     private final Hashtable<BlockVector, BasePortal> indexPortalBlocks = new Hashtable<>();
 
+    // Recipes
+    @Getter
+    private final List<NamespacedKey> recipes = new ArrayList<>();
+
     // Configuration
     public PortalManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -86,12 +90,14 @@ public class PortalManager {
             RecipeConfig r = config.getRecipe();
             try {
                 ItemStack item = createPortalBlock(name);
-                ShapedRecipe recipe = new ShapedRecipe(new NamespacedKey(plugin, name), item);
+                NamespacedKey key = new NamespacedKey(plugin, name);
+                ShapedRecipe recipe = new ShapedRecipe(key, item);
                 recipe.shape(r.getItems().toArray(new String[0]));
                 for (Map.Entry<Character, Material> ingredient : r.getMapping().entrySet()) {
                     recipe.setIngredient(ingredient.getKey(), ingredient.getValue());
                 }
                 plugin.getServer().addRecipe(recipe);
+                recipes.add(key);
             } catch (InvalidPortalException ignored) {
             }
         }

--- a/src/main/java/au/com/grieve/portalnetwork/listeners/PortalEvents.java
+++ b/src/main/java/au/com/grieve/portalnetwork/listeners/PortalEvents.java
@@ -131,6 +131,17 @@ public class PortalEvents implements Listener {
 
     @SuppressWarnings("unused")
     @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        // Grant knowledge of the crafting recipe to all players.
+        // Ideally this should only happen once the player has picked up
+        // all of the items in a given recipe, but there's too much overhead
+        // to track all that.
+        PortalManager manager = PortalNetwork.getInstance().getPortalManager();
+        event.getPlayer().discoverRecipes(manager.getRecipes());
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler
     public void onPlayerQuitEvent(PlayerQuitEvent event) {
         ignore.remove(event.getPlayer());
     }


### PR DESCRIPTION
Grants knowledge of the crafting recipe to all players the first time they join the server.

Ideally this should only happen once the player has picked up all of the items in a given recipe, but there's too much overhead to track all that.